### PR TITLE
Add BBCode Parser to helpers

### DIFF
--- a/util/exceptions.php
+++ b/util/exceptions.php
@@ -38,6 +38,17 @@ class DatabaseConnectionException extends Exception
     }
 }
 
+class MissingKeysException extends Exception
+{
+    public $missing_keys;
+    
+    public function __construct($message = "", $code = 0, Throwable $previous = null , $missing_keys = [])
+    {
+        $this->missing_keys = $missing_keys;
+        parent::__construct($message, $code, $previous);
+    }
+}
+
 
 /**
  * Custom exception handler to catch and display errors in a user-friendly way.

--- a/util/helpers.php
+++ b/util/helpers.php
@@ -114,10 +114,3 @@ function parseBBCode($text, $required)
     return $result;
 }
 
-// require all unkeyed values and a value called 'Prerrequisitos'
-$parsed = parseBBCode($value, ['unkeyed', 'Prerrequisitos']);
-
-if (isset($parsed) && $parsed !== false) {
-    echo '<pre>' . json_encode($parsed, JSON_PRETTY_PRINT) . '</pre>';
-    $_SESSION['success'] = 'Se ha actualizado la descripción del curso con éxito';
-}

--- a/util/helpers.php
+++ b/util/helpers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Dumps the given variables and ends the script.
  *
@@ -31,4 +32,92 @@ function quote($string)
         return $string;
     }
     return '\'' . $string . '\'';
+}
+
+
+
+/**
+ * Parse a BBCode-like string and return an associative array of the values
+ *
+ * The string is expected to be split into lines, where each line is either
+ * - a title, prefixed with a '#'
+ * - a subtitle, prefixed with a '-'
+ * - a description, which is not prefixed with either. 
+ * The description will be the first unkeyed value detected (without a prefixing '#').
+ *
+ * @param string $text the string to parse
+ * @param array $required the keys that must be present in the output
+ * @return array the associative array of values, or false if any of the
+ *  required keys were missing
+ * @throws MissingKeysException if any of the required keys were missing, you can access the missing keys with $e->missing_keys
+ * 
+ * Example
+ * ```php
+ * $text = " 
+ * My daily shopping list today
+ * # Shopping List
+ * - Tomato
+ * - Lettuce
+ * ";
+ * 
+ * parseBBCode($text, ['Shopping List']);
+ * 
+ * // returns: ['Shopping List' => ['Tomato', 'Lettuce'], 'unkeyed' => 'My daily shopping list today']
+ * ```
+ */
+function parseBBCode($text, $required)
+{
+    // it is expected that the text is split into lines
+    $lines = preg_split('/\r?\n/', $text);
+
+
+    $result = []; // the result array which will contain all keys and unkeyed values
+    $currentTitle = false; // keep track of the previous title for listing items (prefixed with '-')
+
+    foreach ($lines as $line) {
+        // Remove trailing and leading spaces
+        $line = trim($line);
+
+        if (empty($line)) {
+            continue;
+        }
+
+        if (strpos($line, '#') === 0) {
+            // the line is a title:
+            $currentTitle = trim(substr($line, 1)); // keep track of the current title
+            $result[$currentTitle] = []; // create an empty array for the current title
+
+        } elseif (strpos($line, '-') === 0) {
+            // the line is a list item:
+            if ($currentTitle === false) {
+                continue; // skip the line if there is no current title
+            }
+
+            $result[$currentTitle][] = trim(substr($line, 1)); // append the list item to the current title
+        } else {
+            // if the line is not keyed or prefixed with any special key:
+            if (!isset($result['unkeyed'])) {
+                // this will only store the first occurrence of this unkeyed value, everything else will be ignored.
+                $result['unkeyed']  = $line;
+            }
+        }
+    }
+
+    // validate the output to contain necessary keys
+    $missing_keys = array_diff($required, array_keys($result));
+
+    if (count($missing_keys) > 0) {
+        throw new MissingKeysException('The following keys are missing: ' . implode(', ', $missing_keys), 400, null, $missing_keys);
+        return false;
+    }
+
+    return $result;
+}
+
+// require all unkeyed values and a value called 'Prerrequisitos'
+$parsed = parseBBCode($value, ['unkeyed', 'Prerrequisitos']);
+
+if (isset($parsed) && $parsed !== false) {
+    echo '<pre>' . json_encode($parsed, JSON_PRETTY_PRINT) . '</pre>';
+    $_SESSION['success'] = 'Se ha actualizado la descripción del curso con éxito';
 }


### PR DESCRIPTION
## Generic BB Code Parser
Simple generic code for parsing BB Code-Like textareas that are separated by \r\n (new lines).

Example:

  ```php
 $text = " 
 My daily shopping list today
 # Shopping List
 - Tomato
 - Lettuce
  "; // assume $text is a textarea value passed from a form
 parseBBCode($text, ['Shopping List', 'unkeyed']); // pass 'Shopping List' as a required key
 // returns: ['Shopping List' => ['Tomato', 'Lettuce'], 'unkeyed' => 'My daily shopping list today']
```
## Error handling 
Added `MissingKeysException` to be thrown if the required key is not found on the text. A class property called `missing_keys` can be accessed in order to view the missing keys and their title.

For example:
```php
try{
 parseBBCode($text, ['Prerequisites', 'unkeyed']); 
} catch (MissingKeysException $e) {
    $_SESSION['error'] = "Error, there were some keys missing " . implode(', ', $e->missing_keys);
}
